### PR TITLE
Add redis server in staging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,10 +40,17 @@ services:
       - free_currconv_api_key
     environment:
       - FREE_CURRCONV_API_KEY_FILE=/run/secrets/free_currconv_api_key
+      - REDIS_SERVER_AND_PORT=redis:6379
+      - REDIS_CACHE_DURATION_IN_MINUTES=60
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     restart: unless-stopped
-  watchtower:
+redis:
+    image: redis:6.0.9
+    restart: unless-stopped
+    labels:
+      com.centurylinklabs.watchtower.enable: "false"
+watchtower:
     image: containrrr/watchtower
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
* Add redis server in staging for currency-service. The currency service now support caching via redis to make the API more reliable and less likely to overuse the capacity of the free API token of 100 requests per hour. This means we can query up to 100 stocks without hitting the API by caching the results in redis.  